### PR TITLE
Add -bind_port flag to set proxy port

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ Usage: ./phantom-<os> [options] -server <server-ip>
 
 Options:
   -bind string
-    	IP address to listen on, port is randomized (default "0.0.0.0")
+    	IP address to listen on, port is randomized by default - see: bind_port (default "0.0.0.0")
+  -bind_port int
+    	Port to listen on - 0 means a random port will be used (default 0)
   -server string
     	Bedrock/MCPE server IP address and port (ex: 1.2.3.4:19132)
   -timeout int
@@ -53,8 +55,8 @@ all UDP traffic for the phantom executable.
 
 **A note on `-bind`:**
 
-The port is randomized and specifically omitted from the flag because the
-port that phantom runs on is irrelevant to the user. phantom must bind to
+The port is randomized by default and specifically omitted from the flag because
+the port that phantom runs on is irrelevant to the user. phantom must bind to
 port 19132 on all interfaces (or at least the broadcast address) to receive
 ping packets from LAN devices. So phantom will always do that and there's no
 way to configure otherwise, but you can also pick which IP you want the proxy
@@ -62,6 +64,13 @@ itself to listen on, just in case you need that. You shouldn't though.
 
 As long as the device you run phantom from is on the same LAN, the default
 settings should allow other LAN devices to see it when you open Minecraft.
+
+**A note on `-bind_port`:**
+
+The port used by proxy can be defined with this flag. It can be useful if you are
+behind a firewall and want to open only necessary ports to phantom.
+This flag can be used with or without the `-bind` flag. 
+Default value is 0. 0 means a random port will be used. 
 
 **Example**
 
@@ -74,9 +83,20 @@ $ ./phantom-<os> 104.219.6.162:19132
 Same as above but bind to a specific local IP:
 
 ```bash
-$ ./phantom-<os> -bind 10.0.0.5:19132 104.219.6.162:19132
+$ ./phantom-<os> -bind 10.0.0.5 104.219.6.162:19132
 ```
 
+Same as above but bind to a specific local proxy port:
+   
+   ```bash
+   $ ./phantom-<os> -bind_port 54321 104.219.6.162:19132
+   ```
+
+Same as above but bind to a specific local IP and port:
+   
+   ```bash
+   $ ./phantom-<os> -bind 10.0.0.5 -bind_port 54321 104.219.6.162:19132
+   ```
 ## Building
 
 Makefile builds for Windows, macOS, and Linux, including x86 and ARM.

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -11,9 +11,11 @@ import (
 
 var bindAddressString string
 var serverAddressString string
+var bindPortInt uint16
 
 func main() {
-	bindArg := flag.String("bind", "0.0.0.0", "IP address to listen on, port is randomized")
+	bindArg := flag.String("bind", "0.0.0.0", "IP address to listen on, port is randomized by default - see: bind_port")
+	bindPortArg := flag.Int("bind_port", 0, "Port to listen on - 0 means a random port will be used (default 0)")
 	serverArg := flag.String("server", "", "Bedrock/MCPE server IP address and port (ex: 1.2.3.4:19132)")
 	timeoutArg := flag.Int("timeout", 60, "Seconds to wait before cleaning up a disconnected client")
 
@@ -28,11 +30,13 @@ func main() {
 	bindAddressString = *bindArg
 	serverAddressString = *serverArg
 	idleTimeout := time.Duration(*timeoutArg) * time.Second
+	bindPortInt = uint16(*bindPortArg)
 
 	fmt.Printf("Starting up with remote server IP: %s\n", serverAddressString)
 
 	proxyServer, err := proxy.New(proxy.ProxyPrefs{
 		bindAddressString,
+		bindPortInt,
 		serverAddressString,
 		idleTimeout,
 	})

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -36,6 +36,7 @@ type ProxyServer struct {
 
 type ProxyPrefs struct {
 	BindAddress  string
+	BindPort     uint16
 	RemoteServer string
 	IdleTimeout  time.Duration
 }
@@ -51,9 +52,14 @@ type connResponse struct {
 }
 
 func New(prefs ProxyPrefs) (*ProxyServer, error) {
-	randSource := rand.NewSource(time.Now().UnixNano())
-	randomPort := (uint16(randSource.Int63()) % 14000) + 50000
-	prefs.BindAddress = fmt.Sprintf("%s:%d", prefs.BindAddress, randomPort)
+
+	port := prefs.BindPort
+	if port == 0 {
+		randSource := rand.NewSource(time.Now().UnixNano())
+		port = (uint16(randSource.Int63()) % 14000) + 50000
+	}
+
+	prefs.BindAddress = fmt.Sprintf("%s:%d", prefs.BindAddress, port)
 
 	bindAddress, err := net.ResolveUDPAddr("udp", prefs.BindAddress)
 	if err != nil {


### PR DESCRIPTION
I implemented a feature requested by me. See: #45 

A new flag `-bind_port` has been added to be able to specify the local proxy port.