### PR TITLE
Make map access safe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,43 @@
 .PHONY: prep
 
 OUT=bin/phantom-windows.exe bin/phantom-windows-32bit.exe bin/phantom-macos bin/phantom-linux bin/phantom-linux-arm5 bin/phantom-linux-arm6 bin/phantom-linux-arm7
+CMDSRC=phantom.go
 
 build: prep ${OUT}
 
 bin/phantom-windows.exe:
 	pushd cmd && \
-	GOOS=windows GOARCH=amd64 go build -o ../bin/phantom-windows.exe proxy.go && \
+	GOOS=windows GOARCH=amd64 go build -o ../bin/phantom-windows.exe ${CMDSRC} && \
 	popd
 
 bin/phantom-windows-32bit.exe:
 	pushd cmd && \
-	GOOS=windows GOARCH=386 go build -o ../bin/phantom-windows-32bit.exe proxy.go && \
+	GOOS=windows GOARCH=386 go build -o ../bin/phantom-windows-32bit.exe ${CMDSRC} && \
 	popd
 
 bin/phantom-macos:
 	pushd cmd && \
-	GOOS=darwin GOARCH=amd64 go build -o ../bin/phantom-macos proxy.go && \
+	GOOS=darwin GOARCH=amd64 go build -o ../bin/phantom-macos ${CMDSRC} && \
 	popd
 
 bin/phantom-linux:
 	pushd cmd && \
-	GOOS=linux GOARCH=amd64 go build -o ../bin/phantom-linux proxy.go && \
+	GOOS=linux GOARCH=amd64 go build -o ../bin/phantom-linux ${CMDSRC} && \
 	popd
 
 bin/phantom-linux-arm5:
 	pushd cmd && \
-	GOOS=linux GOARCH=arm GOARM=5 go build -o ../bin/phantom-linux-arm5 proxy.go && \
+	GOOS=linux GOARCH=arm GOARM=5 go build -o ../bin/phantom-linux-arm5 ${CMDSRC} && \
 	popd
 
 bin/phantom-linux-arm6:
 	pushd cmd && \
-	GOOS=linux GOARCH=arm GOARM=6 go build -o ../bin/phantom-linux-arm6 proxy.go && \
+	GOOS=linux GOARCH=arm GOARM=6 go build -o ../bin/phantom-linux-arm6 ${CMDSRC} && \
 	popd
 
 bin/phantom-linux-arm7:
 	pushd cmd && \
-	GOOS=linux GOARCH=arm GOARM=7 go build -o ../bin/phantom-linux-arm7 proxy.go && \
+	GOOS=linux GOARCH=arm GOARM=7 go build -o ../bin/phantom-linux-arm7 ${CMDSRC} && \
 	popd
 
 prep:
@@ -45,3 +46,5 @@ prep:
 clean:
 	rm -rf bin
 
+test:
+	go test ./...

--- a/cmd/phantom.go
+++ b/cmd/phantom.go
@@ -63,6 +63,8 @@ func usage() {
 	flag.PrintDefaults()
 }
 
+// Watches for CTRL + C signals and shuts down the server
+// A second CTRL + C will force it to exit immediately
 func watchForInterrupt(proxyServer *proxy.ProxyServer) {
 	signalChan := make(chan os.Signal, 1)
 

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.12
 require (
 	github.com/libp2p/go-reuseport v0.0.1
 	github.com/stretchr/testify v1.3.0
+	github.com/tevino/abool v0.0.0-20170917061928-9b9efcf221b5
 )

--- a/go.sum
+++ b/go.sum
@@ -9,5 +9,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/tevino/abool v0.0.0-20170917061928-9b9efcf221b5 h1:hNna6Fi0eP1f2sMBe/rJicDmaHmoXGe1Ta84FPYHLuE=
+github.com/tevino/abool v0.0.0-20170917061928-9b9efcf221b5/go.mod h1:f1SCnEOt6sc3fOJfPQDRDzHOtSXuTtnz0ImG9kPRDV0=
 golang.org/x/sys v0.0.0-20190228124157-a34e9553db1e h1:ZytStCyV048ZqDsWHiYDdoI2Vd4msMcrDECFxS+tL9c=
 golang.org/x/sys v0.0.0-20190228124157-a34e9553db1e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/clientmap/clientmap.go
+++ b/internal/clientmap/clientmap.go
@@ -1,0 +1,126 @@
+package clientmap
+
+import (
+	"net"
+	"sync"
+	"time"
+
+	"github.com/jhead/phantom/internal/logging"
+)
+
+type ClientMap struct {
+	IdleTimeout       time.Duration
+	IdleCheckInterval time.Duration
+	clients           map[string]clientEntry
+	dead              bool
+	mutex             *sync.RWMutex
+}
+
+type clientEntry struct {
+	conn       *net.UDPConn
+	lastActive time.Time
+}
+
+type ServerConnHandler func(*net.UDPConn)
+
+var logger = logging.Get()
+
+func New(idleTimeout time.Duration, idleCheckInterval time.Duration) *ClientMap {
+	clientMap := ClientMap{
+		idleTimeout,
+		idleCheckInterval,
+		make(map[string]clientEntry),
+		false,
+		&sync.RWMutex{},
+	}
+
+	// Start goroutine for cleaning up idle connections
+	go clientMap.idleCleanupLoop()
+
+	return &clientMap
+}
+
+func (cm *ClientMap) Close() {
+	cm.dead = true
+
+	cm.mutex.RLock()
+	for _, client := range cm.clients {
+		client.conn.Close()
+	}
+	cm.mutex.RUnlock()
+}
+
+func (cm *ClientMap) idleCleanupLoop() {
+	logger.Println("Starting idle connection handler")
+
+	// Loop forever using a channel that emits every IdleCheckInterval
+	for currentTime := range time.Tick(cm.IdleCheckInterval) {
+		// Stop the idle cleanup goroutine if the proxy stopped
+		if cm.dead {
+			break
+		}
+
+		cm.mutex.Lock()
+		for key, client := range cm.clients {
+			if client.lastActive.Add(cm.IdleTimeout).Before(currentTime) {
+				logger.Printf("Cleaning up idle connection: %s", key)
+				cm.clients[key].conn.Close()
+				delete(cm.clients, key)
+			}
+		}
+		cm.mutex.Unlock()
+	}
+}
+
+// Get gets or creates a new UDP connection to the remote server
+// and stores it in a map, matching clients to remote server connections.
+// This way, we keep one UDP connection open to the server for each Minecraft
+// client that's connected to the proxy.
+func (cm *ClientMap) Get(
+	clientAddr net.Addr,
+	remote *net.UDPAddr,
+	handler ServerConnHandler,
+) (*net.UDPConn, error) {
+	key := clientAddr.String()
+
+	// Check if connection exists
+	cm.mutex.RLock()
+
+	if client, ok := cm.clients[key]; ok {
+		cm.mutex.RUnlock()
+		client.lastActive = time.Now()
+		return client.conn, nil
+	}
+
+	cm.mutex.RUnlock()
+	cm.mutex.Lock()
+	defer cm.mutex.Unlock()
+
+	// New connection needed
+	logger.Printf("Opening connection to %s for new client %s!\n", remote, clientAddr)
+	newServerConn, err := newServerConnection(remote)
+	if err != nil {
+		return nil, err
+	}
+
+	cm.clients[key] = clientEntry{
+		newServerConn,
+		time.Now(),
+	}
+
+	// Launch goroutine to pass packets from server to client
+	go handler(newServerConn)
+
+	return newServerConn, nil
+}
+
+func newServerConnection(remote *net.UDPAddr) (*net.UDPConn, error) {
+	logger.Printf("Opening connection to %s\n", remote)
+
+	conn, err := net.DialUDP("udp", nil, remote)
+	if err != nil {
+		return nil, err
+	}
+
+	return conn, nil
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,12 @@
+package logging
+
+import (
+	"log"
+	"os"
+)
+
+var logger = log.New(os.Stdout, "INFO: ", log.Ldate|log.Ltime|log.Lshortfile)
+
+func Get() *log.Logger {
+	return logger
+}

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -105,7 +105,6 @@ func readPong(raw string) PongData {
 
 	util.MapFieldsToStruct(pongParts, &pong)
 
-	fmt.Printf("%v\n", pong)
 	return pong
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
-	"os"
-	"strings"
 	"time"
 
 	"github.com/jhead/phantom/internal/clientmap"

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2,35 +2,33 @@ package proxy
 
 import (
 	"fmt"
-	"log"
 	"math/rand"
 	"net"
 	"os"
+	"strings"
 	"time"
 
+	"github.com/jhead/phantom/internal/clientmap"
+	"github.com/jhead/phantom/internal/logging"
 	"github.com/jhead/phantom/internal/proto"
+	"github.com/tevino/abool"
 
 	reuse "github.com/libp2p/go-reuseport"
 )
 
 const maxMTU = 1472
 
-var logger = log.New(os.Stdout, "INFO: ", log.Ldate|log.Ltime|log.Lshortfile)
-var idleCheckInterval = time.Duration(5) * time.Second
-
-type clientMap map[string]*net.UDPConn
-type idleMap map[string]time.Time
+var logger = logging.Get()
+var idleCheckInterval = 5 * time.Second
 
 type ProxyServer struct {
 	bindAddress         *net.UDPAddr
 	remoteServerAddress *net.UDPAddr
 	pingServer          net.PacketConn
 	server              *net.UDPConn
-	clients             clientMap
-	idleMap             idleMap
-	lookupChan          chan connLookup
-	dead                bool
+	clientMap           *clientmap.ClientMap
 	prefs               ProxyPrefs
+	dead                *abool.AtomicBool
 }
 
 type ProxyPrefs struct {
@@ -38,16 +36,6 @@ type ProxyPrefs struct {
 	BindPort     uint16
 	RemoteServer string
 	IdleTimeout  time.Duration
-}
-
-type connLookup struct {
-	client       net.Addr
-	responseChan chan connResponse
-}
-
-type connResponse struct {
-	conn *net.UDPConn
-	err  error
 }
 
 func New(prefs ProxyPrefs) (*ProxyServer, error) {
@@ -77,11 +65,9 @@ func New(prefs ProxyPrefs) (*ProxyServer, error) {
 		remoteServerAddress,
 		nil,
 		nil,
-		make(clientMap),
-		make(idleMap),
-		make(chan connLookup),
-		false,
+		clientmap.New(prefs.IdleTimeout, idleCheckInterval),
 		prefs,
+		abool.New(),
 	}, nil
 }
 
@@ -106,16 +92,6 @@ func (proxy *ProxyServer) Start() error {
 
 	logger.Printf("Proxy server listening!")
 
-	// Close connection upon exit
-	defer proxy.server.Close()
-	defer proxy.pingServer.Close()
-
-	// Start goroutine for cleaning up idle connections
-	go proxy.idleConnectionCleanup()
-
-	// Start goroutine for concurrent client connection map access
-	go proxy.serverConnectionLookupLoop()
-
 	// Start proxying ping packets from the broadcast listener
 	go proxy.readLoop(proxy.pingServer)
 
@@ -125,32 +101,31 @@ func (proxy *ProxyServer) Start() error {
 	return nil
 }
 
-func (proxy *ProxyServer) Stop() {
+func (proxy *ProxyServer) Close() {
 	logger.Println("Stopping proxy server")
 
-	// Stop UDP listener
+	// Stop UDP listeners
 	proxy.server.Close()
+	proxy.pingServer.Close()
 
 	// Close all connections
-	for _, conn := range proxy.clients {
-		conn.Close()
-	}
+	proxy.clientMap.Close()
 
 	// Stop loops
-	proxy.dead = true
+	proxy.dead.Set()
 }
 
 func (proxy *ProxyServer) readLoop(listener net.PacketConn) {
 	packetBuffer := make([]byte, maxMTU)
 
-	for !proxy.dead {
+	for !proxy.dead.IsSet() {
 		err := proxy.processDataFromClients(listener, packetBuffer)
 		if err != nil {
 			logger.Printf("Error while processing client data: %s\n", err)
 		}
 	}
 
-	logger.Println("Proxy server shut down")
+	logger.Printf("Listener shut down: %s\n", listener.LocalAddr())
 }
 
 func (proxy *ProxyServer) processDataFromClients(listener net.PacketConn, packetBuffer []byte) error {
@@ -161,7 +136,17 @@ func (proxy *ProxyServer) processDataFromClients(listener net.PacketConn, packet
 
 	data := packetBuffer[:read]
 
-	serverConn, err := proxy.getServerConnection(client)
+	// Handler triggered when a new client connects and we create a new connetion to the remote server
+	onNewConnection := func(newServerConn *net.UDPConn) {
+		proxy.processDataFromServer(newServerConn, client)
+	}
+
+	serverConn, err := proxy.clientMap.Get(
+		client,
+		proxy.remoteServerAddress,
+		onNewConnection,
+	)
+
 	if err != nil {
 		return err
 	}
@@ -171,73 +156,12 @@ func (proxy *ProxyServer) processDataFromClients(listener net.PacketConn, packet
 	return err
 }
 
-func (proxy *ProxyServer) serverConnectionLookupLoop() {
-	for !proxy.dead {
-		lookup := <-proxy.lookupChan
-		conn, err := getServerConnection(proxy, lookup.client)
-		lookup.responseChan <- connResponse{conn, err}
-	}
-}
-
-func (proxy *ProxyServer) getServerConnection(client net.Addr) (*net.UDPConn, error) {
-	lookup := connLookup{
-		client,
-		make(chan connResponse),
-	}
-
-	proxy.lookupChan <- lookup
-
-	response := <-lookup.responseChan
-
-	return response.conn, response.err
-}
-
-// getServerConnection gets or creates a new UDP connection to the remote server
-// and stores it in a map, matching clients to remote server connections.
-// This way, we keep one UDP connection open to the server for each Minecraft
-// client that's connected to the proxy.
-func getServerConnection(proxy *ProxyServer, client net.Addr) (*net.UDPConn, error) {
-	key := client.String()
-
-	// Store time for cleanup later
-	proxy.idleMap[key] = time.Now()
-
-	// Connection exists
-	if conn, ok := proxy.clients[key]; ok {
-		return conn, nil
-	}
-
-	// New connection needed
-	logger.Printf("Opening connection to %s for new client %s!\n", proxy.remoteServerAddress, client)
-	conn, err := proxy.newServerConnection()
-	if err != nil {
-		return nil, err
-	}
-
-	proxy.clients[key] = conn
-
-	// Launch goroutine to pass packets from server to client
-	go proxy.processDataFromServer(conn, client)
-
-	return conn, nil
-}
-
-func (proxy *ProxyServer) newServerConnection() (*net.UDPConn, error) {
-	logger.Printf("Opening connection to %s\n", proxy.remoteServerAddress)
-	conn, err := net.DialUDP("udp", nil, proxy.remoteServerAddress)
-	if err != nil {
-		return nil, err
-	}
-
-	return conn, nil
-}
-
 // processDataFromServer proxies packets sent by the server to us for a specific
 // Minecraft client back to that client's UDP connection.
 func (proxy *ProxyServer) processDataFromServer(remoteConn *net.UDPConn, client net.Addr) {
 	buffer := make([]byte, maxMTU)
 
-	for !proxy.dead {
+	for !proxy.dead.IsSet() {
 		read, _, err := remoteConn.ReadFrom(buffer)
 
 		// Read error
@@ -266,24 +190,5 @@ func (proxy *ProxyServer) processDataFromServer(remoteConn *net.UDPConn, client 
 		}
 
 		proxy.server.WriteTo(data, client)
-	}
-}
-
-func (proxy *ProxyServer) idleConnectionCleanup() {
-	logger.Println("Starting idle connection handler")
-
-	for !proxy.dead {
-		currentTime := time.Now()
-
-		for key, lastActive := range proxy.idleMap {
-			if lastActive.Add(proxy.prefs.IdleTimeout).Before(currentTime) {
-				logger.Printf("Cleaning up idle connection: %s", key)
-				proxy.clients[key].Close()
-				delete(proxy.clients, key)
-				delete(proxy.idleMap, key)
-			}
-		}
-
-		time.Sleep(idleCheckInterval)
 	}
 }


### PR DESCRIPTION
Credit to @d5c4b3 for the initial impl in #48 
Attempts to fix #44 

- Decouples client connection storage from the proxy server impl
- Replaces concurrent map access with synchronized access using a `sync.RWMutex`
- Makes `dead` flag access safe using an atomic boolean
- Adds a CTRL + C handler