### PR TITLE
Add ability to specify the port to bind to.

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -51,9 +51,13 @@ type connResponse struct {
 }
 
 func New(prefs ProxyPrefs) (*ProxyServer, error) {
-	randSource := rand.NewSource(time.Now().UnixNano())
-	randomPort := (uint16(randSource.Int63()) % 14000) + 50000
-	prefs.BindAddress = fmt.Sprintf("%s:%d", prefs.BindAddress, randomPort)
+	if strings.ContainsAny(prefs.BindAddress, ":") {
+		prefs.BindAddress = prefs.BindAddress
+	} else {
+		randSource := rand.NewSource(time.Now().UnixNano())
+		randomPort := (uint16(randSource.Int63()) % 14000) + 50000
+		prefs.BindAddress = fmt.Sprintf("%s:%d", prefs.BindAddress, randomPort)
+}
 
 	bindAddress, err := net.ResolveUDPAddr("udp", prefs.BindAddress)
 	if err != nil {


### PR DESCRIPTION
Fix #35.
The option -bind can now be call with and without a port number.
`-bind 0.0.0.0:12345`
or
`-bind 0.0.0.0`
If called without a port, the port is selected randomly.