### PR TITLE
Unconnected pinging the remote, custom response on offline

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bytes"
 	"fmt"
 	"math/rand"
 	"net"
@@ -28,6 +29,7 @@ type ProxyServer struct {
 	clientMap           *clientmap.ClientMap
 	prefs               ProxyPrefs
 	dead                *abool.AtomicBool
+	pongData            *proto.UnconnectedPing
 }
 
 type ProxyPrefs struct {
@@ -73,6 +75,7 @@ func New(prefs ProxyPrefs) (*ProxyServer, error) {
 		clientmap.New(prefs.IdleTimeout, idleCheckInterval),
 		prefs,
 		abool.New(),
+		nil,
 	}, nil
 }
 
@@ -120,10 +123,81 @@ func (proxy *ProxyServer) Start() error {
 	log.Info().Msgf("Proxy server listening!")
 	log.Info().Msgf("Once your console pings phantom, you should see replies below.")
 
+	// Start unconnectedpinging the remote server
+	proxy.pingRemoteServer()
+
 	// Start processing everything else using the proxy listener
 	proxy.readLoop(proxy.server)
 
 	return nil
+}
+
+func (proxy *ProxyServer) pingRemoteServer() {
+	go func() {
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				data := proxy.ping()
+				if data != nil && data.Pong.Edition == "MCPE" {
+					proxy.pongData = data
+				} else {
+					proxy.pongData = &proto.UnconnectedPing{
+						PingTime: []byte{0, 0, 0, 0, 0, 0, 0, 0},
+						ID:       []byte{0, 0, 0, 0, 0, 0, 0, 0},
+						Magic:    []byte{0x00, 0xff, 0xff, 0x00, 0xfe, 0xfe, 0xfe, 0xfe, 0xfd, 0xfd, 0xfd, 0xfd, 0x12, 0x34, 0x56, 0x78},
+						Pong: proto.PongData{
+							Edition:         "MCPE",
+							MOTD:            "Server offline",
+							ProtocolVersion: "390",
+							Version:         "1.14.60",
+							Players:         "0",
+							MaxPlayers:      "0",
+							GameType:        "Creative",
+							NintendoLimited: "1",
+						},
+					}
+				}
+			}
+		}
+	}()
+}
+
+func (proxy *ProxyServer) ping() *proto.UnconnectedPing {
+	conn, err := net.DialUDP("udp", nil, proxy.remoteServerAddress)
+	if err != nil {
+		return nil
+	}
+
+	defer conn.Close()
+
+	var buffer bytes.Buffer
+
+	buffer.WriteByte(proto.UnconnectedPingID)
+	buffer.Write([]byte{0, 0, 0, 0})
+	buffer.Write([]byte{0, 34, 45, 79})
+	buffer.Write([]byte{0x00, 0xff, 0xff, 0x00, 0xfe, 0xfe, 0xfe, 0xfe, 0xfd, 0xfd, 0xfd, 0xfd, 0x12, 0x34, 0x56, 0x78})
+
+	if _, err := conn.Write(buffer.Bytes()); err != nil {
+		return nil
+	}
+
+	// Set a read deadline so that we get a timeout if the server doesn't respond to us.
+	_ = conn.SetReadDeadline(time.Now().Add(time.Second * 5))
+
+	data := make([]byte, 1492)
+	n, err := conn.Read(data)
+	if err != nil {
+		return nil
+	}
+	data = data[:n]
+
+	if packet, err := proto.ReadUnconnectedPing(data); err == nil {
+		return packet
+	} else {
+		return nil
+	}
 }
 
 func (proxy *ProxyServer) Close() {
@@ -192,6 +266,17 @@ func (proxy *ProxyServer) processDataFromClients(listener net.PacketConn, packet
 
 	if packetID := data[0]; packetID == proto.UnconnectedPingID {
 		log.Info().Msgf("Received LAN ping from client: %s", client.String())
+
+		// only if pongData settled from pingRemoteServer()
+		if proxy.pongData != nil {
+			replyBuffer := proxy.pongData.Build()
+			replyBytes := proxy.rewriteUnconnectedPong(replyBuffer.Bytes())
+
+			proxy.server.WriteTo(replyBytes, client)
+			log.Info().Msgf("Sent LAN pong to client: %v", client.String())
+		}
+
+		return nil
 	}
 
 	// Write packet from client to server
@@ -221,12 +306,6 @@ func (proxy *ProxyServer) processDataFromServer(remoteConn *net.UDPConn, client 
 		// Resize data to byte count from 'read'
 		data := buffer[:read]
 		log.Trace().Msgf("server recv: %v", data)
-
-		// Rewrite Unconnected Pong packets
-		if packetID := data[0]; packetID == proto.UnconnectedPongID {
-			data = proxy.rewriteUnconnectedPong(data)
-			log.Info().Msgf("Sent LAN pong to client: %v", client.String())
-		}
 
 		proxy.server.WriteTo(data, client)
 	}


### PR DESCRIPTION
With this changes the server always pings the remote server and if it is offline then sends back the clients an offline server status so the clients always receives a stored pong structure or offline pong structure, client unconnected pings will be never sent to the remote server.